### PR TITLE
등록단계에서 이미지를 업로드하고 상세페이지에서 이미지를 볼 수 있도록 기능 추가하였습니다.

### DIFF
--- a/03.react/todoapp/src/pages/TodoInfo/TodoInfo.tsx
+++ b/03.react/todoapp/src/pages/TodoInfo/TodoInfo.tsx
@@ -11,10 +11,12 @@ const TodoInfo = (props: TodoInfoProps) => {
   const [isUpdate, setIsUpdate] = useState(false);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [imageSrc, setImageSrc] = useState("");
   const [isDone, setIsDone] = useState(false);
   const [updateTime, setUpdateTime] = useState("");
 
   let item: TodoItem;
+  let textSrc;
 
   const getTodoDetail = async () => {
     try {
@@ -23,8 +25,10 @@ const TodoInfo = (props: TodoInfoProps) => {
       );
       if (response.data.ok === 1) {
         item = response.data.item;
+        textSrc = item.content.split("*이미지값*")[0];
         setTitle(item.title);
-        setContent(item.content);
+        setContent(textSrc);
+        setImageSrc(item.content.split("*이미지값*")[1]);
         setIsDone(item.done);
         setUpdateTime(item.updatedAt);
       }
@@ -44,7 +48,7 @@ const TodoInfo = (props: TodoInfoProps) => {
         `http://localhost:33088/api/todolist/${id}`,
         {
           title: title,
-          content: content,
+          content: textSrc,
           done: isDone,
         }
       );
@@ -77,6 +81,7 @@ const TodoInfo = (props: TodoInfoProps) => {
           onChange={onChangeTitle}
         />
         <div className="time">{updateTime}</div>
+        {imageSrc && <img className="image-data" src={imageSrc} alt="Image" />}
         <textarea
           className="content-textarea"
           placeholder="TODO 상세 내용을 입력하세요"
@@ -84,7 +89,7 @@ const TodoInfo = (props: TodoInfoProps) => {
           value={content}
           onChange={onChangeContent}
         ></textarea>
-        <div className="button-container">
+        <div className="button-container-info">
           <button onClick={handleUpdateButton} className="info-button edit">
             {isUpdate === false ? "수정" : "완료"}
           </button>

--- a/03.react/todoapp/src/pages/TodoInfo/todoinfo.css
+++ b/03.react/todoapp/src/pages/TodoInfo/todoinfo.css
@@ -9,8 +9,8 @@
   background-color: var(--color-sub);
 }
 
-.button-container {
-  width: 200px;
+.button-container-info {
+  width: 110px;
   height: 40px;
   display: flex;
   justify-content: space-between;
@@ -53,7 +53,7 @@
   font-size: 20px;
   height: 300px;
   font-weight: 400;
-  order: 4;
+  order: 5;
   padding-top: 10px;
 }
 
@@ -74,4 +74,13 @@
   font-weight: 400;
   margin: 0 0 10px 8px;
   order: 3;
+}
+
+.image-data {
+  border-radius: 30px;
+  width: 100px;
+  height: 100px;
+  margin: 0 auto;
+  padding: 5px;
+  order: 4;
 }

--- a/03.react/todoapp/src/pages/TodoInfo/todoinfo.css
+++ b/03.react/todoapp/src/pages/TodoInfo/todoinfo.css
@@ -10,7 +10,7 @@
 }
 
 .button-container {
-  width: 110px;
+  width: 200px;
   height: 40px;
   display: flex;
   justify-content: space-between;

--- a/03.react/todoapp/src/pages/TodoRegist/TodoRegist.tsx
+++ b/03.react/todoapp/src/pages/TodoRegist/TodoRegist.tsx
@@ -1,21 +1,46 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import axios from "axios";
 
 const TodoRegist = () => {
   const [show, setShow] = useState(true);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [imageSrc, setImageSrc] = useState("");
+  const imageInput = useRef(null);
 
   const handleRegistButton = async () => {
     const response: TodoResponse = await axios.post(
       `http://localhost:33088/api/todolist`,
       {
         title: title,
-        content: content,
+        content: `${content} ${imageSrc.replace(
+          "data:image/jpeg;base64,",
+          ""
+        )}`,
       }
     );
     if (response.data.ok === 0) {
       console.log(response);
+    }
+  };
+
+  const handleImageButton = () => {
+    console.log("이미지 핸들 함수 동작");
+    imageInput.current.click();
+  };
+
+  const encodeFileToBase64 = (fileBlob: any) => {
+    console.log(fileBlob);
+    if (fileBlob) {
+      const reader = new FileReader();
+      reader.readAsDataURL(fileBlob);
+      reader.onload = (e: any) => {
+        setImageSrc(reader.result + "");
+      };
+      console.log("이미지 변환 완료");
+    } else {
+      setImageSrc("");
+      console.log("이미지 변환 실패");
     }
   };
 
@@ -56,6 +81,8 @@ const TodoRegist = () => {
             <button
               onClick={(e) => {
                 e.preventDefault();
+                handleImageButton();
+                console.log("이미지 업로드 버튼 클릭");
                 // setShow(false);
               }}
               className="regist-buttons image"
@@ -66,8 +93,12 @@ const TodoRegist = () => {
               className="image-input"
               type="file"
               accept="image/*"
-              // multiple={true} 여러개 파일 업로드 속성
-            ></input>
+              ref={imageInput}
+              multiple={true}
+              onChange={(e) => {
+                encodeFileToBase64(e.target.files[0]);
+              }}
+            />
             {/* 이미지 업로드 기능 추가 */}
           </div>
           <input

--- a/03.react/todoapp/src/pages/TodoRegist/TodoRegist.tsx
+++ b/03.react/todoapp/src/pages/TodoRegist/TodoRegist.tsx
@@ -13,10 +13,7 @@ const TodoRegist = () => {
       `http://localhost:33088/api/todolist`,
       {
         title: title,
-        content: `${content} ${imageSrc.replace(
-          "data:image/jpeg;base64,",
-          ""
-        )}`,
+        content: `${content}*이미지값*${imageSrc}`,
       }
     );
     if (response.data.ok === 0) {

--- a/03.react/todoapp/src/pages/TodoRegist/TodoRegist.tsx
+++ b/03.react/todoapp/src/pages/TodoRegist/TodoRegist.tsx
@@ -52,6 +52,23 @@ const TodoRegist = () => {
             >
               취소
             </button>
+            {/* 이미지 업로드 기능 추가 */}
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                // setShow(false);
+              }}
+              className="regist-buttons image"
+            >
+              image
+            </button>
+            <input
+              className="image-input"
+              type="file"
+              accept="image/*"
+              // multiple={true} 여러개 파일 업로드 속성
+            ></input>
+            {/* 이미지 업로드 기능 추가 */}
           </div>
           <input
             type="text"

--- a/03.react/todoapp/src/pages/TodoRegist/todoregist.css
+++ b/03.react/todoapp/src/pages/TodoRegist/todoregist.css
@@ -9,6 +9,16 @@
   background-color: var(--color-sub);
 }
 
+.button-container {
+  width: 210px;
+  height: 40px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 0 10px 5px;
+  order: 1;
+}
+
 .regist-title {
   font-size: 24px;
   height: 30px;

--- a/03.react/todoapp/src/pages/TodoRegist/todoregist.css
+++ b/03.react/todoapp/src/pages/TodoRegist/todoregist.css
@@ -57,3 +57,13 @@
   color: var(--color-cancel);
   border: 1px solid var(--color-cancel);
 }
+
+.image-input {
+  display: none;
+}
+
+.image {
+  width: 90px;
+  color: var(--color-main);
+  border: 1px solid var(--color-main);
+}


### PR DESCRIPTION
### 변경사항
<img width="568" alt="image" src="https://github.com/rlawlsdn263/FESP01-JS-Project/assets/96248861/1c5e9620-9f45-48ba-88af-f8342033306e">

- 등록페이지에서 이미지 버튼이 생성되었습니다.
- 이미지 버튼은 이미지파일만 업로드할 수 있도록 제한하였습니다. (동영상, PDF 등 기타 파일 X)
- api를 수정할 수 없으므로 한정된 자원을 사용하기 위해 이미지는 base64로 변환하여 content에 보내집니다.

<img width="536" alt="image" src="https://github.com/rlawlsdn263/FESP01-JS-Project/assets/96248861/129317a7-eefb-4948-95c4-b8e6490853bf">

- 서버에서 받아올 때 split을 이용하여 내용과 이미지를 분리하여 렌더링할 수 있도록 기능을 추가하였습니다.
- 이미지가 없을 경우에는 img 태그가 보이지 않도록 하였습니다.

### 더 추가하면 좋은 기능
- 수정페이지에서도 이미지를 삭제하거나 등록할 수 있도록 추가하기